### PR TITLE
fix(swarm-key): generate random bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const os = require('os')
+const crypto = require('crypto')
+
 exports = module.exports = function getSwarmKey(){
-    const buf = Buffer.allocUnsafe(32);
+    const buf = crypto.randomBytes(32); 
     return `/key/swarm/psk/1.0.0/${os.EOL}/base16/${os.EOL}${buf.toString('hex')}`;
 }


### PR DESCRIPTION
Generate the 32 byte buffer using `crypto.randomBytes()`.